### PR TITLE
[FIX] 승인조건 등록에서 DEAL_NO가 비어있어 INSERT 기능이 작동하지 않던 문제를 수정

### DIFF
--- a/src/main/java/com/nanuri/rams/business/common/dto/IBIMS208BDTO.java
+++ b/src/main/java/com/nanuri/rams/business/common/dto/IBIMS208BDTO.java
@@ -5,9 +5,11 @@ import java.util.Date;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
+@ToString
 /* 
  IB승인조건내역 - 대출채권/채무보증 정보(TB06010S) - 셀다운승인조건 Table.IBIMS208B DTO
 */

--- a/src/main/java/com/nanuri/rams/business/common/vo/IBIMS208BVO.java
+++ b/src/main/java/com/nanuri/rams/business/common/vo/IBIMS208BVO.java
@@ -4,9 +4,11 @@ import com.nanuri.rams.business.common.dto.IBIMS208BDTO;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Setter
 @Getter
+@ToString(callSuper = true)
 /* 
 IB승인조건내역 - 대출채권/채무보증 정보(TB06010S) - 셀다운승인조건 Table.IBIMS208B VO
 */

--- a/src/main/resources/static/js/business/tb/TB06012P.js
+++ b/src/main/resources/static/js/business/tb/TB06012P.js
@@ -174,7 +174,7 @@ function regIBIMS208B() {
   }
 
   var paramData = {
-    dealNo: $("#"+$("#TB06012P_prefix").val()+"_ibDealNo").val(), // 딜번호
+    dealNo: $("#TB06012P_ibDealNo").val(), // 딜번호
     sn: $("#TB06012P_sn").val(), // 일련번호
     sdwnDtDcd: $("#TB06012P_D007").val(), // 샐다운일자구분코드
     sdwnTlmtMnum: $("#TB06012P_sdwnTlmtMnum").val(), // 샐다운기한개월수


### PR DESCRIPTION
[FIX] 승인조건 등록에서 DEAL_NO가 비어있어 INSERT 기능이 작동하지 않던 문제를 수정
1. IBIMS208BDTO toString 어노테이션 추가
2. IBIMS208BVO toString(callSuper = true) 어노테이션 추가
3. TB06012P.js 에서 비동기 요청 시 dealNo 변수의 참조 id 변경

🎃 