### PR TITLE
[CHORE] 롬복 toStrinmg 어노테이션 사용 시 상속받는 superClass의 field도 불러오도록 옵션 조정

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+# 롬복 toStrinmg 어노테이션 사용 시 상속받는 superClass의 field도 불러오도록 옵션 조정
+lombok.toString.callSuper = call

--- a/src/main/java/com/nanuri/rams/business/common/vo/IBIMS208BVO.java
+++ b/src/main/java/com/nanuri/rams/business/common/vo/IBIMS208BVO.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 
 @Setter
 @Getter
-@ToString(callSuper = true)
+@ToString
 /* 
 IB승인조건내역 - 대출채권/채무보증 정보(TB06010S) - 셀다운승인조건 Table.IBIMS208B VO
 */


### PR DESCRIPTION
[CHORE] 롬복 toStrinmg 어노테이션 사용 시 상속받는 superClass의 field도 불러오도록 옵션 조정
🌵 